### PR TITLE
修改task.py的命令行选项

### DIFF
--- a/test/task_struct/task.py
+++ b/test/task_struct/task.py
@@ -16,7 +16,7 @@ parser = argparse.ArgumentParser(
     description="Extraction the data of the task_struct",)
 
 # 定义必须参数pid
-parser.add_argument("pid", help="the process's pid")
+parser.add_argument("pid", help="please input pid")
 
 args = parser.parse_args()
 

--- a/test/task_struct/task.py
+++ b/test/task_struct/task.py
@@ -15,7 +15,8 @@ import time
 parser = argparse.ArgumentParser(
     description="Extraction the data of the task_struct",)
 
-parser.add_argument("-P", "--pid", help="the process's pid")
+# 定义必须参数pid
+parser.add_argument("pid", help="the process's pid")
 
 args = parser.parse_args()
 


### PR DESCRIPTION
在bcc c代码中，pid用来做必要的判断，所以将命令行中的PID改为必须选项，必须输入PID，才能启动程序。